### PR TITLE
Bugfix: Fix insert() on empty file and delete() handling

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -19,7 +19,10 @@ class Buffer:
 
     def insert(self, cursor, string):
         row, col = cursor.row, cursor.col
-        current = self.lines.pop(row)
+        try:
+            current = self.lines.pop(row)
+        except IndexError:
+            current = ''
         new = current[:col] + string + current[col:]
         self.lines.insert(row, new)
 
@@ -33,7 +36,7 @@ class Buffer:
         row, col = cursor.row, cursor.col
         if (row, col) < (self.bottom, len(self[row])):
             current = self.lines.pop(row)
-            if col < len(self[row]):
+            if col < len(current):
                 new = current[:col] + current[col + 1:]
                 self.lines.insert(row, new)
             else:


### PR DESCRIPTION
Fixing a couple issues with the insert() / delete() handling.

# insert() issue:
When opening an empty file and attempting the call to insert(), an `IndexError` exception is raised because the Buffer().lines is an empty list.
```
Traceback (most recent call last):
  File "/home/user/editor.py", line 187, in <module>
    curses.wrapper(main)
  File "/home/user/.pyenv/versions/3.11.3/lib/python3.11/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/editor.py", line 181, in main
    buffer.insert(cursor, k)
  File "/home/user/editor.py", line 22, in insert
    current = self.lines.pop(row)
              ^^^^^^^^^^^^^^^^^^^
IndexError: pop from empty list
```

Adding a `try: ... except IndexError: ...` logic corrects this behavior to use an empty string if none is found.

# delete(): issue
When hitting the backspace key when the next line is shorter than the current line, or when hitting the backspace key on the last line of the file, the current logic is using the length of the next line to determine if the line should be combined with the next line or not. If on the last line, this causes an `IndexError` exception. If not on the last line, but the Cursor.col is greater than the length of the next line, it falls into the `else` logic combining the next line with the current line incorrectly.

For example, if I hit the `backspace` key when the cursor is on the `w` in line two:
![editor_py delete issue](https://github.com/user-attachments/assets/f944e565-96d6-4c5c-a902-6c78cbc9a3f3)

This fix updates it so we are comparing the length of the current line to see if the current line should be combined or not.