### PR TITLE
fix: prevent crash on horizontal scrolling with long lines

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -116,8 +116,8 @@ class Window:
             self.row += 1
 
     def horizontal_scroll(self, cursor, left_margin=5, right_margin=2):
-        n_pages = cursor.col // (self.n_cols - right_margin)
-        self.col = max(n_pages * self.n_cols - right_margin - left_margin, 0)
+        n_pages = max((cursor.col - left_margin) // (self.n_cols - right_margin - left_margin), 0)
+        self.col = max(n_pages * (self.n_cols - right_margin - left_margin), 0)
 
     def translate(self, cursor):
         return cursor.row - self.row, cursor.col - self.col

--- a/editor.py
+++ b/editor.py
@@ -116,8 +116,9 @@ class Window:
             self.row += 1
 
     def horizontal_scroll(self, cursor, left_margin=5, right_margin=2):
-        n_pages = max((cursor.col - left_margin) // (self.n_cols - right_margin - left_margin), 0)
-        self.col = max(n_pages * (self.n_cols - right_margin - left_margin), 0)
+        page_n_cols = self.n_cols - left_margin - right_margin
+        n_pages = max((cursor.col - left_margin) // page_n_cols, 0)
+        self.col = n_pages * page_n_cols
 
     def translate(self, cursor):
         return cursor.row - self.row, cursor.col - self.col


### PR DESCRIPTION
Uses both margins in the `n_pages` computation to prevent `window.col` > `cursor.col` and thus returning a negative value in `window.translate`
fix: #4 